### PR TITLE
🐛 버튼, 헤더 버그 수정, 스타일 개선

### DIFF
--- a/client/src/components/atoms/Button/style.scss
+++ b/client/src/components/atoms/Button/style.scss
@@ -1,5 +1,5 @@
 button.atom {
   outline: none;
   border: none;
-  background-color: var(--color-white);
+  background-color: none;
 }

--- a/client/src/components/molecules/Button/normal/normal-button.js
+++ b/client/src/components/molecules/Button/normal/normal-button.js
@@ -8,7 +8,7 @@ export const createNormalButton = ({
   onClick,
   label,
   size = "medium",
-  disabled,
+  disabled = false,
 }) => {
   const isNotSupported = !BUTTON_SIZE.includes(size);
 

--- a/client/src/components/organisms/header/style.scss
+++ b/client/src/components/organisms/header/style.scss
@@ -1,7 +1,12 @@
 .header {
   display: flex;
+  align-items: center;
   justify-content: space-between;
   padding: 0 24px;
+  height: 56px;
+  > div {
+    width: 24px;
+  }
   &-white {
     background-color: var(--color-white);
   }

--- a/client/src/styles/style.scss
+++ b/client/src/styles/style.scss
@@ -16,3 +16,8 @@
 html {
   font-family: "NotoSansKR";
 }
+
+body {
+  padding: 0;
+  margin: 0;
+}


### PR DESCRIPTION
- 아톰 버튼 background가 다른 버튼에 적용되는 버그 수정
- normal-button disabled 디폴트 설정
- 헤더에서 빈 div width 추가
  - width가 0일 경우 정렬이 제대로 안됨. (동적으로 width 넣을 방법 생각해보면 좋을 거 같아요)
- body padding, margin 0